### PR TITLE
chore(demo): remove Support Ukraine banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,10 +34,6 @@
 </head>
 
 <body class="vh-100 d-flex flex-column">
-    <div class="hstack bg-black no-print">
-        <a class="mx-auto p-2 text-white" href="https://war.ukraine.ua">Support Ukraine 🇺🇦</a>
-    </div>
-
     <div class="hstack p-2 gap-2 bg-light no-print">
 
         <input id="files" type="file" class="form-control" style="width: 50ch;" accept=".docx" />


### PR DESCRIPTION
Removes the banner from `index.html` to keep the demo UI politically neutral.