### PR TITLE
chore: add npm run dev / npm run serve static server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,8 @@ Follow this order for any change that affects rendering:
 ### Browser-test recipe
 
 ```bash
-python3 -m http.server 8765 &    # serve repo root
+npm run serve &                  # Node static server on :8765 (PORT=… to override)
+#   — or `npm run dev` to rebuild first
 # then, via Playwright MCP:
 #   browser_navigate → http://localhost:8765/?test=<fixture>
 #   browser_evaluate → set docxOptions.*, call renderDocx(currentDocument)

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "build": "rollup --config rollup.config.mjs",
     "build-prod": "rollup --config rollup.config.mjs --environment BUILD:production",
     "watch": "rollup --config rollup.config.mjs --watch",
+    "serve": "node scripts/dev-server.mjs",
+    "dev": "npm run build && npm run serve",
     "e2e": "karma start karma.conf.cjs --single-run",
     "e2e-watch": "karma start karma.conf.cjs",
     "test:track-changes": "npm run build && node scripts/test-track-changes.mjs"

--- a/scripts/dev-server.mjs
+++ b/scripts/dev-server.mjs
@@ -1,0 +1,64 @@
+// Tiny static file server for the demo. Serves the repo root on port 8765
+// (configurable via PORT env var). Used by `npm run dev` / `npm run serve`.
+
+import { createServer } from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { resolve, extname, normalize } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(fileURLToPath(import.meta.url), '../..');
+const port = Number(process.env.PORT) || 8765;
+
+const MIME = {
+    '.html': 'text/html; charset=utf-8',
+    '.js':   'application/javascript; charset=utf-8',
+    '.mjs':  'application/javascript; charset=utf-8',
+    '.css':  'text/css; charset=utf-8',
+    '.json': 'application/json; charset=utf-8',
+    '.svg':  'image/svg+xml',
+    '.png':  'image/png',
+    '.jpg':  'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif':  'image/gif',
+    '.ico':  'image/x-icon',
+    '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    '.map':  'application/json; charset=utf-8',
+    '.woff': 'font/woff',
+    '.woff2':'font/woff2',
+    '.ttf':  'font/ttf',
+};
+
+const server = createServer(async (req, res) => {
+    try {
+        const url = new URL(req.url, `http://localhost:${port}`);
+        let path = decodeURIComponent(url.pathname);
+        if (path.endsWith('/')) path += 'index.html';
+        // Resolve and confirm the path stays inside the repo (no traversal).
+        const full = normalize(resolve(root, '.' + path));
+        if (!full.startsWith(root)) {
+            res.writeHead(403).end('Forbidden');
+            return;
+        }
+        const info = await stat(full);
+        if (info.isDirectory()) {
+            res.writeHead(301, { Location: path + '/' }).end();
+            return;
+        }
+        const body = await readFile(full);
+        res.writeHead(200, {
+            'Content-Type': MIME[extname(full)] ?? 'application/octet-stream',
+            'Content-Length': body.length,
+            // Prevent the browser from caching stale dist/*.js while iterating.
+            'Cache-Control': 'no-store',
+        });
+        res.end(body);
+    } catch (err) {
+        if (err.code === 'ENOENT') res.writeHead(404).end('Not Found');
+        else { res.writeHead(500).end('Server Error'); console.error(err); }
+    }
+});
+
+server.listen(port, () => {
+    console.log(`docxjs demo → http://localhost:${port}/`);
+    console.log(`try:          http://localhost:${port}/?test=revision-rich`);
+});


### PR DESCRIPTION
Adds a small zero-dep Node static file server at \`scripts/dev-server.mjs\` and wires up two new scripts:

- \`npm run serve\` — serves the repo root on :8765 (set \`PORT=\` to override)
- \`npm run dev\` — rebuilds, then serves

Replaces the \`python3 -m http.server\` recipe in CLAUDE.md. The server:
- Sends \`Cache-Control: no-store\` so edits to \`dist/*.js\` show up without manual cache-busting.
- Rejects path-traversal requests via \`normalize\` + \`startsWith(root)\`.
- Ships the DOCX MIME type so the browser loads \`.docx\` fixtures with the right \`Content-Type\`.

Verified: \`/\`, \`/index.html\`, \`/dist/docx-preview.js\`, and \`/tests/render-test/revision-rich/document.docx\` all serve 200; \`/../etc/passwd\` returns 404.