### PR TITLE
chore(demo): remove Test Documents dropdown and test scaffolding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,16 +23,18 @@ Follow this order for any change that affects rendering:
 npm run serve &                  # Node static server on :8765 (PORT=… to override)
 #   — or `npm run dev` to rebuild first
 # then, via Playwright MCP:
-#   browser_navigate → http://localhost:8765/?test=<fixture>
+#   browser_navigate → http://localhost:8765/
+#   browser_file_upload → tests/render-test/<fixture>/document.docx
+#     (uploaded to the `#files` input; fileInput.change fires renderDocx)
 #   browser_evaluate → set docxOptions.*, call renderDocx(currentDocument)
 #   browser_evaluate → querySelectorAll and assert
 #   browser_take_screenshot for visual evidence
 #   kill %1 when done
 ```
 
-The `index.html` demo exposes `docxOptions`, `renderDocx`, and `currentDocument` as globals, so the Playwright flow is driven almost entirely through `browser_evaluate`.
+The `index.html` demo exposes `docxOptions`, `renderDocx`, and `currentDocument` as globals, so the Playwright flow is driven almost entirely through `browser_evaluate` once a file is loaded.
 
-Fixtures live in `tests/render-test/<name>/document.docx`. The demo's test dropdown is populated from a hardcoded list in `index.html` — add new fixture names there if you want them selectable via `?test=<name>`.
+Fixtures live in `tests/render-test/<name>/document.docx`. The demo has no in-UI fixture picker — load a DOCX via the file input or drag-drop (users of a production viewer shouldn't see test scaffolding).
 
 ## Architecture touch points
 

--- a/index.html
+++ b/index.html
@@ -37,11 +37,6 @@
     <div class="hstack p-2 gap-2 bg-light no-print">
 
         <input id="files" type="file" class="form-control" style="width: 50ch;" accept=".docx" />
-        <div class="col-2">
-            <select id="testDocuments" class="form-select">
-                <option disabled selected>-- Test Documents --</option>
-            </select>
-        </div>
         <button id="loadButton" class="btn btn-primary px-4">Reload</button>
         <div class="dropdown">
             <button class="btn btn-secondary dropdown-toggle" type="button" id="optionsMenuButton"
@@ -51,7 +46,6 @@
             <ul id="optionsMenu" class="dropdown-menu" aria-labelledby="optionsMenuButton">
             </ul>
         </div>
-        <button id="saveTestButton" class="btn btn-primary px-4" style="display: none">Save Test</button>
     </div>
 
     <div class="flex-grow-1 d-flex flex-row" style="height: 0;">
@@ -73,7 +67,6 @@
         const container = document.querySelector("#document-container");
         const fileInput = document.querySelector("#files");
         const loadButton = document.querySelector("#loadButton");
-        const testDocuments = document.querySelector("#testDocuments");
 
         async function renderDocx(file) {
             currentDocument = file; 
@@ -90,10 +83,7 @@
             console.log(res);
         }
         
-        fileInput.addEventListener("change", ev => {
-            renderDocx(fileInput.files[0]);
-            testDocuments.selectedIndex = 0;
-        });
+        fileInput.addEventListener("change", ev => renderDocx(fileInput.files[0]));
         loadButton.addEventListener("click", ev => renderDocx(fileInput.files[0]));
 
         const menu = document.querySelector("#optionsMenu");
@@ -137,36 +127,6 @@
             ev.preventDefault();
             renderDocx(ev.dataTransfer.files[0]);
         });
-
-        const selectedTest = new URLSearchParams(location.search).get('test');
-
-        for (let testName of ['text','underlines','text-break','line-spacing','numbering','page-layout','table','table-spans','footnote','header-footer','revision','revision-rich','equation'])
-        {
-            var op = document.createElement("option");
-            op.value = testName;
-            op.label = testName;
-            op.selected = testName == selectedTest;
-            testDocuments.add(op);
-        }
-
-        testDocuments.addEventListener("change", e => tryLoadTest(testDocuments.value));
-
-        tryLoadTest(selectedTest);
-
-        document.querySelector("#saveTestButton").addEventListener("click", async () => {
-            const file = await showSaveFilePicker({ types: [ { description: "HTML File", accept: { "text/html": [".html"] } }] });
-            const stream = await file.createWritable();
-            await stream.write(container.innerHTML);
-            await stream.close();
-        });
-
-        async function tryLoadTest(testName) {
-            if (testName) {
-                let resp = await fetch(`tests/render-test/${testName}/document.docx`);
-                renderDocx(await resp.blob());
-                fileInput.value = "";
-            }
-        }
     </script>
 </body>
 


### PR DESCRIPTION
Strips all test-flavoured UI from the demo so it presents as a production document viewer:

- The \`-- Test Documents --\` dropdown and its option-population loop.
- The \`?test=<fixture>\` URL-param handler and \`tryLoadTest()\`.
- The hidden \`#saveTestButton\` (test-fixture capture helper).

Users now load a DOCX via the file input or drag-drop only. Track-changes options remain in the Options menu.

CLAUDE.md updated: the Playwright recipe now uploads via \`browser_file_upload\` against \`#files\` instead of navigating to \`?test=<name>\`.

Verified end-to-end via Playwright: navigated to \`/\`, uploaded \`tests/render-test/revision-rich/document.docx\` via the file input, turned on \`changes.show\` — 2 formatting revisions, 2 change bars, legend showing Sara Kitaoji. Rendering pipeline unchanged.