### PR TITLE
fix(types): narrow parseAsync / renderAsync / renderDocument return types (#117)

### DIFF
--- a/dist/docx-preview.d.ts
+++ b/dist/docx-preview.d.ts
@@ -56,4 +56,4 @@ export type WordDocument = any;
 export declare const defaultOptions: Options;
 export declare function parseAsync(data: Blob | any, userOptions?: Partial<Options>): Promise<WordDocument>;
 export declare function renderDocument(document: WordDocument, userOptions?: Partial<Options>): Promise<Node[]>;
-export declare function renderAsync(data: Blob | any, bodyContainer: HTMLElement, styleContainer?: HTMLElement, userOptions?: Partial<Options>): Promise<any>;
+export declare function renderAsync(data: Blob | any, bodyContainer: HTMLElement, styleContainer?: HTMLElement, userOptions?: Partial<Options>): Promise<WordDocument>;

--- a/src/docx-preview.ts
+++ b/src/docx-preview.ts
@@ -132,18 +132,18 @@ function mergeOptions(userOptions?: Partial<Options>): Options {
     return ops;
 }
 
-export function parseAsync(data: Blob | any, userOptions?: Partial<Options>): Promise<any>  {
+export function parseAsync(data: Blob | any, userOptions?: Partial<Options>): Promise<WordDocument>  {
     const ops = mergeOptions(userOptions);
     return WordDocument.load(data, new DocumentParser(ops), ops);
 }
 
-export async function renderDocument(document: any, userOptions?: Partial<Options>): Promise<any> {
+export async function renderDocument(document: any, userOptions?: Partial<Options>): Promise<Node[]> {
     const ops = mergeOptions(userOptions);
     const renderer = new HtmlRenderer();
     return await renderer.render(document, ops);
 }
 
-export async function renderAsync(data: Blob | any, bodyContainer: HTMLElement, styleContainer?: HTMLElement, userOptions?: Partial<Options>): Promise<any> {
+export async function renderAsync(data: Blob | any, bodyContainer: HTMLElement, styleContainer?: HTMLElement, userOptions?: Partial<Options>): Promise<WordDocument> {
 	const doc = await parseAsync(data, userOptions);
 	const nodes = await renderDocument(doc, userOptions);
 


### PR DESCRIPTION
## Summary

Addresses upstream issue [VolodymyrBaydalka/docxjs#117](https://github.com/VolodymyrBaydalka/docxjs/issues/117): the public async API declared `Promise<any>` return types, forcing consumers to lose type information.

This change narrows the three public async entry points in `src/docx-preview.ts`:

- `parseAsync` → `Promise<WordDocument>`
- `renderDocument` → `Promise<Node[]>`
- `renderAsync` → `Promise<WordDocument>`

The hand-maintained `dist/docx-preview.d.ts` bundle has been updated to match so consumers importing the shipped package see identical types from source and from the distribution.

Pure type-only change — no runtime behaviour is altered.

## Verification

- `npm run build` succeeds (rollup warning about `jszip` is pre-existing and external).
- `npm run test:track-changes` — all 13 harness scenarios pass.
- No Playwright / visual runs needed: the rebuilt `dist/docx-preview.js` and source map are byte-identical to the previous build (type narrowing is erased by TS, so UMD output is unchanged).

## Test plan

- [x] `npm run build`
- [x] `npm run test:track-changes` (13/13 pass)
- [ ] Downstream TS consumers can drop their `as WordDocument` casts around `parseAsync` / `renderAsync`