### PR TITLE
fix(sidebar): drop background/border in anchored mode

### DIFF
--- a/dist/docx-preview.js
+++ b/dist/docx-preview.js
@@ -3736,11 +3736,11 @@ section.${c}>ol>li::before {
 .${c}-wrapper { flex-flow: row !important; align-items: flex-start !important; }
 .${c}-doc-container { flex: 1; display: flex; flex-flow: column; align-items: center; min-width: 0; overflow: auto; padding: 30px; padding-bottom: 0; }
 .${c}-doc-container>section.${c} { background: white; box-shadow: 0 0 10px rgba(0, 0, 0, 0.5); margin-bottom: 30px; }
-.${c}-comment-sidebar { width: 320px; min-width: 260px; background: #fafafa; border-left: 1px solid #ddd; display: flex; flex-direction: column; transition: width 0.2s, min-width 0.2s, padding 0.2s; }
-/* packed mode: panel stays pinned as a short compact list at the top of the viewport. */
-.${c}-comment-sidebar.${c}-sidebar-packed { position: sticky; top: 0; height: 100vh; overflow: hidden; align-self: flex-start; }
-/* anchored mode: panel grows to match the document height and rides the same scroll container so each card stays next to its anchor. The toolbar inside it is sticky so it's always visible. */
-.${c}-comment-sidebar.${c}-sidebar-anchored { align-self: stretch; }
+.${c}-comment-sidebar { width: 320px; min-width: 260px; display: flex; flex-direction: column; transition: width 0.2s, min-width 0.2s, padding 0.2s; }
+/* packed mode: panel stays pinned as a short compact list at the top of the viewport. Background + border frame the compact list. */
+.${c}-comment-sidebar.${c}-sidebar-packed { position: sticky; top: 0; height: 100vh; overflow: hidden; align-self: flex-start; background: #fafafa; border-left: 1px solid #ddd; }
+/* anchored mode: panel grows to match the document height and rides the same scroll container so each card stays next to its anchor. No background/border — cards float on the page backdrop. */
+.${c}-comment-sidebar.${c}-sidebar-anchored { align-self: stretch; background: transparent; border-left: none; }
 .${c}-sidebar-packed .${c}-sidebar-content { flex: 1; overflow-y: auto; padding: 8px; }
 .${c}-sidebar-anchored .${c}-sidebar-content { padding: 8px; }
 .${c}-sidebar-comment { background: white; border: 1px solid #e0e0e0; border-radius: 6px; padding: 10px; margin-bottom: 8px; cursor: pointer; transition: box-shadow 0.2s, border-color 0.2s; }

--- a/src/html-renderer.ts
+++ b/src/html-renderer.ts
@@ -884,11 +884,11 @@ section.${c}>ol>li::before {
 .${c}-wrapper { flex-flow: row !important; align-items: flex-start !important; }
 .${c}-doc-container { flex: 1; display: flex; flex-flow: column; align-items: center; min-width: 0; overflow: auto; padding: 30px; padding-bottom: 0; }
 .${c}-doc-container>section.${c} { background: white; box-shadow: 0 0 10px rgba(0, 0, 0, 0.5); margin-bottom: 30px; }
-.${c}-comment-sidebar { width: 320px; min-width: 260px; background: #fafafa; border-left: 1px solid #ddd; display: flex; flex-direction: column; transition: width 0.2s, min-width 0.2s, padding 0.2s; }
-/* packed mode: panel stays pinned as a short compact list at the top of the viewport. */
-.${c}-comment-sidebar.${c}-sidebar-packed { position: sticky; top: 0; height: 100vh; overflow: hidden; align-self: flex-start; }
-/* anchored mode: panel grows to match the document height and rides the same scroll container so each card stays next to its anchor. The toolbar inside it is sticky so it's always visible. */
-.${c}-comment-sidebar.${c}-sidebar-anchored { align-self: stretch; }
+.${c}-comment-sidebar { width: 320px; min-width: 260px; display: flex; flex-direction: column; transition: width 0.2s, min-width 0.2s, padding 0.2s; }
+/* packed mode: panel stays pinned as a short compact list at the top of the viewport. Background + border frame the compact list. */
+.${c}-comment-sidebar.${c}-sidebar-packed { position: sticky; top: 0; height: 100vh; overflow: hidden; align-self: flex-start; background: #fafafa; border-left: 1px solid #ddd; }
+/* anchored mode: panel grows to match the document height and rides the same scroll container so each card stays next to its anchor. No background/border — cards float on the page backdrop. */
+.${c}-comment-sidebar.${c}-sidebar-anchored { align-self: stretch; background: transparent; border-left: none; }
 .${c}-sidebar-packed .${c}-sidebar-content { flex: 1; overflow-y: auto; padding: 8px; }
 .${c}-sidebar-anchored .${c}-sidebar-content { padding: 8px; }
 .${c}-sidebar-comment { background: white; border: 1px solid #e0e0e0; border-radius: 6px; padding: 10px; margin-bottom: 8px; cursor: pointer; transition: box-shadow 0.2s, border-color 0.2s; }


### PR DESCRIPTION
The comment sidebar rendered a visible white panel down the right side of every page, including pages with no comments. In anchored mode the sidebar stretches to the full document height, so the panel chrome (background + left border) turned into a full-length vertical bar even on pages with nothing in it.

Move `background: #fafafa` and `border-left: 1px solid #ddd` out of the base `.docx-comment-sidebar` rule and into the packed-mode rule only (where it's a short compact list and the frame still makes sense). Anchored mode gets `background: transparent; border-left: none` so comment cards float on the page backdrop with no framing panel around them.

### Verified

On paper.docx with `renderComments: true`, `comments.layout: 'anchored'`:

| Property | Before | After |
|---|---|---|
| sidebar `backgroundColor` | `rgb(250, 250, 250)` | `rgba(0, 0, 0, 0)` |
| sidebar `border-left` | `1px solid rgb(221, 221, 221)` | `none` |
| cardCount | 11 | 11 (unchanged) |

Screenshot shows the prior white column is gone; the grey backdrop extends uniformly across the full width.