### PR TITLE
fix(#138): clamp SVG width/height positive, preserve origin via viewBox

### DIFF
--- a/src/html-renderer.ts
+++ b/src/html-renderer.ts
@@ -2032,9 +2032,12 @@ section.${c}>ol>li::before {
 
 		requestAnimationFrame(() => {
 			const bb = (container.firstElementChild as any).getBBox();
-
-			container.setAttribute("width", `${Math.ceil(bb.x +  bb.width)}`);
-			container.setAttribute("height", `${Math.ceil(bb.y + bb.height)}`);
+			// Use extent (width/height) for dimensions and viewBox to preserve negative origins; setAttribute rejects negative lengths.
+			const w = Math.max(1, Math.ceil(bb.width));
+			const h = Math.max(1, Math.ceil(bb.height));
+			container.setAttribute("width", `${w}`);
+			container.setAttribute("height", `${h}`);
+			container.setAttribute("viewBox", `${Math.floor(bb.x)} ${Math.floor(bb.y)} ${w} ${h}`);
 		});
 
 		return container;


### PR DESCRIPTION
## Summary

- Replaces `Math.ceil(bb.x + bb.width)` with `Math.max(1, Math.ceil(bb.width))` for the SVG width/height. The old math produced a negative value whenever a VML shape's bounding box started at a negative origin, and setAttribute threw "Expected length, '-17'".
- Adds a `viewBox` so the shape's coordinate space (including negative origins) still renders correctly inside the clamped container.

Upstream issue: https://github.com/VolodymyrBaydalka/docxjs/issues/138

## Test plan

- [x] `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)