### PR TITLE
docs: refresh README/TODO and require they stay in sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,15 @@ All string content in a DOCX is attacker-controlled. Treat `author`, `id`, `para
 - `.github/workflows/` is intentionally empty (removed 2026-05-01). No automated checks run on PRs; rely on local build + harness + Playwright.
 - `dist/` is committed. Rebuild before any commit that touches `src/`.
 
+### Keep README.md and TODO.md current
+
+Whenever a feature is added, removed, or a public option changes, update both of these files *in the same PR* as the code change — stale docs have bitten us before.
+
+- **`README.md`** — the API block reflects the real `Options` interface. If you add/remove an option (including nested ones like `comments.*` or `changes.*`), add/remove a row in the API code block. If you add or remove an `export` in `src/docx-preview.ts`, reflect it in the API section. The "Breaks" / "Thumbnails" / "Status" prose should also match reality — e.g. if `experimentalPageBreaks` gains a capability, call it out there.
+- **`TODO.md`** — if the change resolves an upstream issue listed under "Bugs to investigate" or "New features to consider", move that entry into the "Resolved in fork" table with a one-line description and the PR number. Update the counts table at the top and bump the "last updated" date.
+
+Minimum check before every PR that touches `src/`: `grep -n "<option name>" README.md TODO.md` to catch stale references.
+
 ## Parallelising work with subagents
 
 When there are multiple independent tasks (bug fixes on different files, triage of many issues, a set of small low-risk patches), prefer spawning **multiple subagents in parallel** over working through them sequentially. The Agent tool accepts `run_in_background: true` — use it. Typical win: 5 small fixes in ~2 minutes wall-clock instead of 10 minutes sequential.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 [![Support Ukraine](https://img.shields.io/badge/Support-Ukraine-blue?style=flat&logo=adguard)](https://war.ukraine.ua/)
 
 # docxjs
-Docx rendering library
+Docx rendering library.
 
-Demo - https://volodymyrbaydalka.github.io/docxjs/
+This repository is a fork of [docxjs](https://github.com/VolodymyrBaydalka/docxjs) by Volodymyr Baydalka. It builds on their original work with additional features — visual page breaks, a comments sidebar, track-changes rendering, repeated headers/footers on split pages, and various security and parsing fixes. Credit for the foundational library goes to the original author.
 
 Goal
 ----
-Goal of this project is to render/convert DOCX document into HTML document with keeping HTML semantic as much as possible. 
+Goal of this project is to render/convert DOCX document into HTML document with keeping HTML semantic as much as possible.
 That means library is limited by HTML capabilities (for example Google Docs renders *.docx document on canvas as an image).
 
 Installation
@@ -40,33 +40,59 @@ API
 ```ts
 // renders document into specified element
 renderAsync(
-    document: Blob | ArrayBuffer | Uint8Array, // could be any type that supported by JSZip.loadAsync
-    bodyContainer: HTMLElement, //element to render document content,
-    styleContainer: HTMLElement, //element to render document styles, numbeings, fonts. If null, bodyContainer will be used.
+    document: Blob | ArrayBuffer | Uint8Array, // any type supported by JSZip.loadAsync
+    bodyContainer: HTMLElement, // element to render document content
+    styleContainer: HTMLElement, // element to render document styles, numberings, fonts. If null, bodyContainer is used.
     options: {
-        className: string = "docx", //class name/prefix for default and document style classes
-        inWrapper: boolean = true, //enables rendering of wrapper around document content
-        hideWrapperOnPrint: boolean = false, //disable wrapper styles on print
-        ignoreWidth: boolean = false, //disables rendering width of page
-        ignoreHeight: boolean = false, //disables rendering height of page
-        ignoreFonts: boolean = false, //disables fonts rendering
-        breakPages: boolean = true, //enables page breaking on page breaks
-        ignoreLastRenderedPageBreak: boolean = true, //disables page breaking on lastRenderedPageBreak elements
-        experimental: boolean = false, //enables experimental features (tab stops calculation)
-        trimXmlDeclaration: boolean = true, //if true, xml declaration will be removed from xml documents before parsing
-        useBase64URL: boolean = false, //if true, images, fonts, etc. will be converted to base 64 URL, otherwise URL.createObjectURL is used
-        renderChanges: false, //enables experimental rendering of document changes (inserions/deletions)
-        renderHeaders: true, //enables headers rendering
-        renderFooters: true, //enables footers rendering
-        renderFootnotes: true, //enables footnotes rendering
-        renderEndnotes: true, //enables endnotes rendering
-        renderComments: false, //enables experimental comments rendering
-        renderAltChunks: true, //enables altChunks (html parts) rendering
-        debug: boolean = false, //enables additional logging
+        className: string = "docx",                    // class name/prefix for default and document style classes
+        inWrapper: boolean = true,                     // render a wrapper around document content
+        hideWrapperOnPrint: boolean = false,           // disable wrapper styles on print
+        ignoreWidth: boolean = false,                  // disable rendering width of page
+        ignoreHeight: boolean = false,                 // disable rendering height of page
+        ignoreFonts: boolean = false,                  // disable fonts rendering
+        breakPages: boolean = true,                    // enable page breaking on DOCX page-break elements
+        ignoreLastRenderedPageBreak: boolean = true,   // disable page breaking on lastRenderedPageBreak elements
+        experimental: boolean = false,                 // enable experimental features (tab stops calculation)
+        trimXmlDeclaration: boolean = true,            // strip XML declaration before parsing
+        useBase64URL: boolean = false,                 // convert images/fonts to base64 URLs instead of object URLs
+        renderHeaders: boolean = true,                 // enable headers rendering
+        renderFooters: boolean = true,                 // enable footers rendering
+        renderFootnotes: boolean = true,               // enable footnotes rendering
+        renderEndnotes: boolean = true,                // enable endnotes rendering
+        renderChanges: boolean = false,                // legacy switch for track-changes; prefer `changes.show` below
+        renderComments: boolean = false,               // enable comments rendering
+        experimentalPageBreaks: boolean = false,       // after rendering, split sections whose content overflows
+                                                       // the page-sized min-height into multiple page-shaped siblings.
+                                                       // Repeats headers/footers and splits oversized tables at row
+                                                       // boundaries. Off by default to preserve current behaviour.
+        comments: {
+            sidebar: boolean = true,                   // render comments in a right-margin sidebar
+            highlight: boolean = true,                 // highlight the anchor text via CSS Highlight API
+            layout: 'anchored' | 'packed' = 'anchored' // 'anchored' aligns each card to its anchor; 'packed' stacks flush
+        },
+        changes: {
+            show: boolean = false,                     // master switch for track-changes rendering
+            showInsertions: boolean = true,
+            showDeletions: boolean = true,
+            showMoves: boolean = true,
+            showFormatting: boolean = true,
+            colorByAuthor: boolean = true,             // color each author's revisions distinctly
+            changeBar: boolean = true,                 // render a marginal bar next to changed paragraphs
+            legend: boolean = true,                    // inject a legend listing authors
+            sidebarCards: boolean = true               // anchor a card per revision in the right margin
+        },
+        debug: boolean = false
     }): Promise<WordDocument>
 
+// Render per-page thumbnails of an already-rendered document into a sibling container.
+renderThumbnails(
+    mainContainer: HTMLElement,      // the container renderAsync wrote into
+    thumbnailContainer: HTMLElement, // where thumbnails should be placed
+    options?: ThumbnailsOptions
+): ThumbnailsHandle
+
 /// ==== experimental / internal API ===
-// this API could be used to modify document before rendering
+// this API can be used to modify a document before rendering
 // renderAsync = parseAsync + renderDocument
 
 // parse document and return internal document object
@@ -80,33 +106,40 @@ renderDocument(
     wordDocument: WordDocument,
     options: Options
 ): Promise<Node[]>
+
+// Drive the visual-page-break pass directly (normally called by renderAsync when
+// experimentalPageBreaks is true). Useful for consumers that assemble the DOM
+// themselves.
+applyVisualPageBreaks(
+    bodyContainer: HTMLElement,
+    options?: { className?: string; slack?: number },
+    measureFn?: MeasureFn
+): number
 ```
 
-Thumbnails, TOC and etc.
+Thumbnails
 ------
-Thumbnails is added only for example and it's not part of library. Library renders DOCX into HTML, so it can't be efficiently used for thumbnails. 
+`renderThumbnails` is a first-class export that renders per-page thumbnails of an already-rendered document into a separate container. Each thumbnail is a clipped clone of the matching page section.
 
-Table of contents is built using the TOC fields and there is no efficient way to get table of contents at this point, since fields is not supported yet (http://officeopenxml.com/WPtableOfContents.php)
+Table of contents
+------
+Table-of-contents rendering is not yet supported. Word builds TOCs via TOC fields, and field evaluation is not implemented (see http://officeopenxml.com/WPtableOfContents.php).
 
 Breaks
 ------
-Currently library does break pages:
-- if user/manual page break `<w:br w:type="page"/>` is inserted - when user insert page break
-- if application page break `<w:lastRenderedPageBreak/>` is inserted - could be inserted by editor application like MS word (`ignoreLastRenderedPageBreak` should be set to false)
-- if page settings for paragraph is changed - ex: user change settings from portrait to landscape page
+The library breaks pages when:
+- a manual page break `<w:br w:type="page"/>` is inserted
+- an application page break `<w:lastRenderedPageBreak/>` is inserted — Word emits these (set `ignoreLastRenderedPageBreak: false` to honour them)
+- page settings change between paragraphs — e.g. portrait to landscape
 
-Realtime page breaking is not implemented because it's requires re-calculation of sizes on each insertion and that could affect performance a lot. 
+In addition, when `experimentalPageBreaks: true`, the library performs visual pagination after rendering: any section whose rendered height exceeds its page-sized `min-height` is split into multiple page-shaped sibling sections. Headers/footers are cloned onto every sub-page, and oversized tables are split at row boundaries (preserving `colgroup` and repeating `thead`). Mid-paragraph splitting is not yet implemented — a paragraph taller than a page will overflow its sub-page.
 
-If page breaking is crutual for you, I would recommend:
-- try to insert manual break point as much as you could
-- try use editors like MS Word, that inserts `<w:lastRenderedPageBreak/>` break points
-
-NOTE: by default `ignoreLastRenderedPageBreak` is set to `true`. You may need to set it to `false`, to make library break by `<w:lastRenderedPageBreak/>` break points
+By default `ignoreLastRenderedPageBreak` is `true`. Set it to `false` to break on `<w:lastRenderedPageBreak/>` points.
 
 Status and stability
 ------
-So far I can't come up with final approach of parsing documents and final structure of API. Only **renderAsync** function is stable and definition shouldn't be changed in future. Inner implementation of parsing and rendering may be changed at any point of time.
+The public surface (`renderAsync`, `parseAsync`, `renderDocument`, `renderThumbnails`) is stable. Newer features behind `experimental*` flags (`experimentalPageBreaks`, revision sidebar cards, etc.) may still change in shape as they settle.
 
 Contributing
 ------
-Please do not include contents of `./dist` folder in your PR's. Otherwise I most likely will reject it due to stability and security concerns.
+This fork commits `dist/` alongside source changes so consumers can pull from git directly. If you open a PR, rebuild `dist/` (via `npm run build`) before committing so the bundled output stays in sync with `src/`.

--- a/TODO.md
+++ b/TODO.md
@@ -2,18 +2,19 @@
 
 Deep review of all 51 open issues + 4 open PRs on the upstream source repo
 [`VolodymyrBaydalka/docxjs`](https://github.com/VolodymyrBaydalka/docxjs/issues)
-as of **2026-05-02**. Each item was compared against the current state of this
-fork (master) and its commit history. Each entry has a category, a
-priority hint, and a short status explaining what we found.
+originally triaged **2026-05-02**; last updated **2026-05-04**. Each item was
+compared against the current state of this fork (master) and its commit
+history. Each entry has a category, a priority hint, and a short status
+explaining what we found.
 
 Counts by category:
 
 | Category | Count |
 |---|---|
-| bug-to-investigate | 24 |
+| bug-to-investigate | 20 |
 | duplicate-or-stale | 9 |
 | new-feature | 8 |
-| resolved-in-fork | 5 |
+| resolved-in-fork | 9 |
 | needs-info | 4 |
 | not-applicable | 3 |
 | upstream-pr-worth-adopting | 2 |
@@ -33,9 +34,11 @@ The two items you should act on first.
 
 The longest-standing upstream complaint. Fixed here: `experimentalPageBreaks`
 option in [`src/page-break.ts`](src/page-break.ts) + per-page thumbnails in
-[`src/thumbnails.ts`](src/thumbnails.ts). Worth promoting off "experimental" once
-the mid-element split case and the header/footer-on-every-page case are handled
-(both noted in PR #24's body).
+[`src/thumbnails.ts`](src/thumbnails.ts). Both follow-up blockers — repeated
+headers/footers on every sub-page and mid-element splitting (table row
+boundaries) — are now shipped (PR #44). The mid-paragraph split case remains
+out of scope. Worth promoting off "experimental" once consumers have had a
+release cycle to validate.
 
 ### [#194 — PR: sanitize hyperlink URIs to prevent XSS](https://github.com/VolodymyrBaydalka/docxjs/pull/194) (resolved-in-fork — triaged earlier, now superseded; high)
 
@@ -106,13 +109,11 @@ Ordered by priority hint.
 | [#76](https://github.com/VolodymyrBaydalka/docxjs/issues/76) | Docx-embedded header/footer render issue | `src/header-footer/` parts |
 | [#80](https://github.com/VolodymyrBaydalka/docxjs/issues/80) | Text box cannot be displayed | Likely tractable — we handle VML textboxes but not DrawingML `wps:txbx`. Good ROI. |
 | [#102](https://github.com/VolodymyrBaydalka/docxjs/issues/102) / [#130](https://github.com/VolodymyrBaydalka/docxjs/issues/130) | Image covers text / image above-or-below text broken | Same root cause: DrawingML wrap/anchor rendering gap. |
-| [#138](https://github.com/VolodymyrBaydalka/docxjs/issues/138) | `<svg>` negative width error | `html-renderer.ts:1825` — `Math.ceil(bb.x + bb.width)` can go negative for VML shapes with a negative origin. |
 | [#155](https://github.com/VolodymyrBaydalka/docxjs/issues/155), [#156](https://github.com/VolodymyrBaydalka/docxjs/issues/156), [#157](https://github.com/VolodymyrBaydalka/docxjs/issues/157), [#158](https://github.com/VolodymyrBaydalka/docxjs/issues/158), [#159](https://github.com/VolodymyrBaydalka/docxjs/issues/159) | Real-world DOCX regressions (batch filed 2025-04-13) | Likely all related to floating-image wrap modes (`wrapSquare`, `wrapTight` not implemented). |
 | [#174](https://github.com/VolodymyrBaydalka/docxjs/issues/174) | Table background / text colour not rendered correctly | Theme color resolution |
 | [#181](https://github.com/VolodymyrBaydalka/docxjs/issues/181) | Numbered lists: numbering continues across multiple previews with default className | Known footgun when mounting multiple renderers on the same page |
 | [#183](https://github.com/VolodymyrBaydalka/docxjs/issues/183) | Source map issue causes CI/CD failures | Our `dist/*.map` also has `sourcesContent: null` + missing src — worth fixing before next release |
 | [#195](https://github.com/VolodymyrBaydalka/docxjs/issues/195) | text-indent incorrect | `firstLineChars` ignored |
-| [#196](https://github.com/VolodymyrBaydalka/docxjs/issues/196) | `classNameOfCnfStyle` throws on null | One-line null-check fix |
 
 ### Low priority
 
@@ -121,9 +122,7 @@ Ordered by priority hint.
 | [#51](https://github.com/VolodymyrBaydalka/docxjs/issues/51) | Equation Editor / Shape rendering | WMF portion out of scope; DrawingML shapes tracked under #167 |
 | [#59](https://github.com/VolodymyrBaydalka/docxjs/issues/59) | Image wrap position wrong | Related to the #102/#130 wrap gap |
 | [#97](https://github.com/VolodymyrBaydalka/docxjs/issues/97) | Text box lines disappear | Same family as #80 |
-| [#117](https://github.com/VolodymyrBaydalka/docxjs/issues/117) | Wrong typings of `WordDocument` | One-liner — `Promise<any>` → `Promise<WordDocument>` at `src/docx-preview.ts:124,135` |
 | [#161](https://github.com/VolodymyrBaydalka/docxjs/issues/161) | `&` appears with curly or square brackets | XML entity escaping in a specific path |
-| [#171](https://github.com/VolodymyrBaydalka/docxjs/issues/171) | Colour format `#4472c4 [3204]` | **Trivial fix at `src/vml/vml.ts:57,107` — unsanitized index suffix.** |
 | [#178](https://github.com/VolodymyrBaydalka/docxjs/issues/178) | tabStops display bug | Tab rendering quirks |
 | [#187](https://github.com/VolodymyrBaydalka/docxjs/issues/187) | Empty `<p>` has wrong height | Empty paragraph placeholder |
 
@@ -135,12 +134,16 @@ Close out on upstream with a link to our commits.
 
 | # | Title | Fix in fork |
 |---|---|---|
-| [#39](https://github.com/VolodymyrBaydalka/docxjs/issues/39) | Page break | `src/page-break.ts` behind `experimentalPageBreaks` (PR #24) |
+| [#39](https://github.com/VolodymyrBaydalka/docxjs/issues/39) | Page break | `src/page-break.ts` behind `experimentalPageBreaks` (PR #24); headers/footers + table row splits (PR #44) |
 | [#85](https://github.com/VolodymyrBaydalka/docxjs/issues/85) | Comments support | Full sidebar feature (PRs #2 etc.) |
+| [#117](https://github.com/VolodymyrBaydalka/docxjs/issues/117) | Wrong typings of `WordDocument` | `parseAsync` / `renderAsync` now return `Promise<WordDocument>` in `src/docx-preview.ts` |
+| [#138](https://github.com/VolodymyrBaydalka/docxjs/issues/138) | `<svg>` negative width error | Clamp to `Math.max(1, Math.ceil(bb.width))` + `viewBox` (PR #43) |
+| [#171](https://github.com/VolodymyrBaydalka/docxjs/issues/171) | Colour format `#4472c4 [3204]` | `sanitizeVmlColor` strips the `[index]` suffix before `sanitizeCssColor` in `src/vml/vml.ts` |
 | [#176](https://github.com/VolodymyrBaydalka/docxjs/issues/176) | Auto-pagination | Same as #39 above |
 | [#179](https://github.com/VolodymyrBaydalka/docxjs/issues/179) | Hyperlinks clickable in preview | `renderHyperlink` opens links; scheme now allowlisted (PR #23) |
 | [#188](https://github.com/VolodymyrBaydalka/docxjs/issues/188) | `renderAsync` not available at runtime | ESM exports set correctly in our build |
 | [#194](https://github.com/VolodymyrBaydalka/docxjs/pull/194) (PR) | Sanitize hyperlink URIs to prevent XSS | PR #23 lands the same fix with a stricter allowlist |
+| [#196](https://github.com/VolodymyrBaydalka/docxjs/issues/196) | `classNameOfCnfStyle` throws on null | Null-guard in `classNameOfCnfStyle` (`src/document-parser.ts`) returns empty class when `w:val` is missing |
 
 ---
 


### PR DESCRIPTION
## Summary

- **README.md** — drop the upstream demo link, add explicit attribution to Volodymyr Baydalka's original project, and bring the API block in line with the current `Options` interface (`experimentalPageBreaks`, nested `comments.*` / `changes.*`, `renderThumbnails`, `applyVisualPageBreaks`). Thumbnails/Breaks/Contributing prose rewritten to match reality.
- **TODO.md** — move #117, #138, #171, #196 to "Resolved in fork" with fix links; note that #39's former blockers (header/footer repeat, table row-boundary split) shipped in PR #44; refresh counts and timestamp.
- **CLAUDE.md** — new rule under Workflow: feature-touching PRs must update README.md/TODO.md in the same change, plus a grep sanity-check recipe.

## Test plan

- [x] Doc-only change — no build/test run needed, but `npm run build` remains clean.
- [x] Verified README API block matches every property in the `Options` interface in `src/docx-preview.ts`.
- [x] Verified TODO entries moved to "Resolved in fork" are actually fixed in master (#117 typings in `src/docx-preview.ts`, #138 viewBox in `src/html-renderer.ts:2036`, #171 `sanitizeVmlColor`, #196 null-guard in `classNameOfCnfStyle`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)