### PR TITLE
docs: link sibling projects in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,13 @@ The public surface (`renderAsync`, `parseAsync`, `renderDocument`, `renderThumbn
 Contributing
 ------
 This fork commits `dist/` alongside source changes so consumers can pull from git directly. If you open a PR, rebuild `dist/` (via `npm run build`) before committing so the bundled output stays in sync with `src/`.
+
+## Related projects
+
+Part of a family of document-rendering libraries:
+
+- [pptxjs](https://github.com/loadfix/pptxjs) — browser-side PPTX → HTML renderer (TypeScript)
+- [xlsxjs](https://github.com/loadfix/xlsxjs) — browser-side XLSX → HTML renderer (TypeScript)
+- [python-docx](https://github.com/loadfix/python-docx) — Python DOCX parser/generator
+- [python-pptx](https://github.com/loadfix/python-pptx) — Python PPTX parser/generator
+- [python-xlsx](https://github.com/loadfix/python-xlsx) — Python XLSX parser/generator


### PR DESCRIPTION
## Summary

Adds a "Related projects" block at the bottom of the README that cross-links to the other 5 forks in the family (pptxjs, xlsxjs, python-docx, python-pptx, python-xlsx). Mirrors the same block the sibling repos are getting in their own docs alignment PRs today.

## Test plan

- [x] Doc-only change.
- [x] Verified each link resolves to an existing `loadfix/*` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)